### PR TITLE
Support for jQuery > 1.7

### DIFF
--- a/example.html
+++ b/example.html
@@ -7,7 +7,8 @@
 		<!--[if IE]>
 			<link href="jphotogrid.ie.css" rel="stylesheet" type="text/css" media="screen" />
 		<![endif]--> 
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+		<script src="http://code.jquery.com/jquery-migrate-1.2.1.js"></script>
 		<script src="jphotogrid.js"></script>
 		<script src="jflickrfeed.js"></script>
 		<script src="setup.js"></script>

--- a/jphotogrid.js
+++ b/jphotogrid.js
@@ -78,13 +78,23 @@
 				},function(){
 					$(this).removeClass(settings.activeClass);
 				});
-			$(document).on('click', '.' + settings.activeClass, function(){				
-				select(this);
-			});
-			$(document).on('click', '.' + settings.selectedClass, function(){
-				hideSelected();
-			});
 			
+			if( $.isFunction($.fn.on) ) {
+				$(document).on('click', '.' + settings.activeClass, function(){				
+					select(this);
+				});
+				$(document).on('click', '.' + settings.selectedClass, function(){
+					hideSelected();
+				});
+			} else {
+				$('.' + settings.activeClass).live('click', function(){				
+					select(this);
+				});
+				$('.' + settings.selectedClass).live('click', function(){
+					hideSelected();
+				});
+			} 
+
 			$(this).find('div')
 				.hover(function(){
 					$(this).css('opacity', 0);

--- a/jphotogrid.js
+++ b/jphotogrid.js
@@ -78,10 +78,10 @@
 				},function(){
 					$(this).removeClass(settings.activeClass);
 				});
-			$('.' + settings.activeClass).live('click', function(){				
+			$(document).on('click', '.' + settings.activeClass, function(){				
 				select(this);
 			});
-			$('.' + settings.selectedClass).live('click', function(){
+			$(document).on('click', '.' + settings.selectedClass, function(){
 				hideSelected();
 			});
 			


### PR DESCRIPTION
Hi Max,
first of all congratulations for the plugin! :)
I tried it with a version of jQuery newer than the original 1.4.2 and as .live() function is deprecated since jQuery version 1.7 I replaced its 2 occurrences into the main js file, adding an existance-check for the jQuery function .on().

To make those changes I took example from official documentation http://api.jquery.com/live/. I tested them on a website with jQuery 1.11.1

I also updated jQuery into the example.html file and added jquery-migrate https://github.com/jquery/jquery-migrate

I hope to have been of some help,
Cheers!
Mario